### PR TITLE
Add Missing TriggerRepeatType in FALanguage

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -576,6 +576,9 @@ NOTICE THAT UNDOREDO AND COPYPASTE HASN'T BEEN SUPPORTED YET!
     TriggerActionParameter = TEXT
     TriggerActionParamValue = TEXT
     TriggerActionDesc = TEXT
+    TriggerRepeatType.OneTimeOr= TEXT
+    TriggerRepeatType.OneTimeAnd= TEXT
+    TriggerRepeatType.RepeatingOr= TEXT
     ScriptTypesTitle = TEXT
     ScriptTypesDesc = TEXT
     ScriptTypesSelectedScript = TEXT


### PR DESCRIPTION
In the release https://github.com/secsome/FA2sp/releases/tag/Release1.5.1 it supprots the TriggerRepeatType in FALanguage but the Doc is missing the configuration key/value.
