### PR TITLE
Allow wall overlays to use custom palettes

### DIFF
--- a/FA2sp/Ext/CLoading/Body.h
+++ b/FA2sp/Ext/CLoading/Body.h
@@ -34,8 +34,8 @@ public:
 	static ppmfc::CString GetBuildingImageName(ppmfc::CString ID, int nFacing, int state);
 	
 	static void ClearItemTypes();
-private:
 	void GetFullPaletteName(ppmfc::CString& PaletteName);
+private:
 	static ppmfc::CString* __cdecl GetDictName(ppmfc::CString* ret, const char* ID, int nFacing) { JMP_STD(0x475450); }
 	static ppmfc::CString GetDictName(ppmfc::CString ID, int nFacing)
 	{

--- a/FA2sp/Ext/CLoading/Hooks.cpp
+++ b/FA2sp/Ext/CLoading/Hooks.cpp
@@ -1,9 +1,12 @@
 #include "Body.h"
 
+#include <Drawing.h>
 #include <CFinalSunApp.h>
 #include <CMixFile.h>
 #include <CLoading.h>
 #include <CINI.h>
+#include "..\..\Miscs\Palettes.h"
+#include "..\CMapData\Body.h"
 
 DEFINE_HOOK(486B00, CLoading_InitMixFiles, 7)
 {
@@ -81,4 +84,26 @@ DEFINE_HOOK(4B8CFC, CMapData_CreateMap_InitMixFiles_Removal, 5)
 	};
 	reinterpret_cast<CLoadingHelper*>(CLoading::Instance())->DTOR();
 	return 0x4B8D0C;
+}
+
+
+DEFINE_HOOK(4903F3, CLoading_DrawOverlay_Palette, 7) 
+{
+	GET(CLoadingExt*, pThis, EDI);
+	REF_STACK(ImageDataClass, pDrawData, STACK_OFFS(0x1C8, 0xC8));
+	GET_STACK(int, nOverlayIndex, STACK_OFFS(0x1C8, -0x8));
+
+	if (nOverlayIndex >= 0 && nOverlayIndex < 255)
+	{
+		auto const& typeData = CMapDataExt::OverlayTypeDatas[nOverlayIndex];
+
+		if (typeData.Wall)
+		{
+			auto palName = typeData.PaletteName;
+			pThis->GetFullPaletteName(palName);
+			pDrawData.pPalette = PalettesManager::LoadPalette(palName);
+		}
+	}
+
+	return 0;
 }

--- a/FA2sp/Ext/CMapData/Body.h
+++ b/FA2sp/Ext/CMapData/Body.h
@@ -8,6 +8,7 @@
 struct OverlayTypeData
 {
     bool Rock;
+    ppmfc::CString PaletteName;
 };
 
 struct BuildingDataExt

--- a/FA2sp/Ext/CMapData/Hooks.cpp
+++ b/FA2sp/Ext/CMapData/Hooks.cpp
@@ -80,6 +80,7 @@ DEFINE_HOOK(47AB50, CLoading_InitPics_InitOverlayTypeDatas, 7)
     {
         auto& item = CMapDataExt::OverlayTypeDatas.emplace_back();
         item.Rock = Variables::Rules.GetBool(id, "IsARock");
+        item.PaletteName = CINI::Art->GetString(id, "Palette", "unit");
     }
 
     return 0;

--- a/FA2sp/Ext/CMapValidator/Body.cpp
+++ b/FA2sp/Ext/CMapValidator/Body.cpp
@@ -36,13 +36,21 @@ void CMapValidatorExt::ValidateStructureOverlapping(BOOL& result)
 				for (int dx = 0; dx < DataExt.Height; ++dx)
 				{
 					for (int dy = 0; dy < DataExt.Width; ++dy)
-						Occupied[CMapData::Instance->GetCoordIndex(X + dx, Y + dy)].emplace_back(splits[1].m_pchData);
+					{
+						MapCoord coord = { X + dx, Y + dy };
+						if (CMapData::Instance->IsCoordInMap(coord.X, coord.Y))
+							Occupied[CMapData::Instance->GetCoordIndex(coord.X, coord.Y)].emplace_back(splits[1].m_pchData);
+					}
 				}
 			}
 			else
 			{
 				for (const auto& block : *DataExt.Foundations)
-					Occupied[CMapData::Instance->GetCoordIndex(X + block.Y, Y + block.X)].emplace_back(splits[1].m_pchData);
+				{
+					MapCoord coord = { X + block.Y, Y + block.X };
+					if (CMapData::Instance->IsCoordInMap(coord.X, coord.Y))
+						Occupied[CMapData::Instance->GetCoordIndex(coord.X, coord.Y)].emplace_back(splits[1].m_pchData);
+				}
 			}
 		}
 	}

--- a/FA2sp/Ext/CPropertyBuilding/Hooks.cpp
+++ b/FA2sp/Ext/CPropertyBuilding/Hooks.cpp
@@ -68,7 +68,7 @@ DEFINE_HOOK(417F40, CPropertyBuilding_OnInitDialog, 7)
                 for (const auto& upgrade : upgrades)
                 {
                     const auto UIName = CMapData::Instance->GetUIName(upgrade.c_str());
-                    const auto name = std::format("{} ({})", upgrade, UIName);
+                    const auto name = std::format("{} ({})", upgrade, UIName.m_pchData);
 
                     for (int i = 0; i < nUpgrades; ++i)
                         pUpgrades[i]->AddString(name.c_str());

--- a/FA2sp/Ext/CTileSetBrowserView/Hooks.cpp
+++ b/FA2sp/Ext/CTileSetBrowserView/Hooks.cpp
@@ -1,3 +1,4 @@
+#include <CPalette.h>
 #include <CTileSetBrowserView.h>
 #include <Helpers/Macro.h>
 
@@ -20,6 +21,23 @@ DEFINE_HOOK(4F258B, CTileSetBrowserView_OnDraw_SetOverlayFrameToDisplay, 7)
     return i < nDisplayLimit ? 0x4F2230 : 0x4F2598;
 }
 
+DEFINE_HOOK(4F22F7, CTileSetBrowserView_OnDraw_OverlayPalette, 5)
+{
+    GET(Palette*, pPalette, EAX);
+    GET_STACK(BytePalette*, pBytePalette, STACK_OFFS(0xDC, 0xBC));
+
+    if (pPalette == Palette::PALETTE_ISO || pPalette == Palette::PALETTE_THEATER || pPalette == Palette::PALETTE_UNIT)
+        return 0;
+
+    *pBytePalette = BytePalette();
+
+    for (int i = 0; i < 256; i++) 
+    {
+        pBytePalette->Data[i] = pPalette->GetByteColor(i);
+    }
+
+    return 0x4F2315;
+}
 
 //DEFINE_HOOK(4F1D70, ASDG, 6)
 //{


### PR DESCRIPTION
This is to support a Phobos feature that allows the same.